### PR TITLE
Allow returning fewer paths per OD (basic generator)

### DIFF
--- a/janux/path_generators/wrapper_functions.py
+++ b/janux/path_generators/wrapper_functions.py
@@ -10,11 +10,12 @@ from .basic_generator import BasicPathGenerator
 def basic_generator(network: nx.DiGraph,
                     origins: list[str], 
                     destinations: list[str],
+                    max_resample_iterations: int = 0,
                     as_df: bool = False,
                     calc_free_flow: bool = False,
                     **kwargs) -> pd.DataFrame:
     generator = BasicPathGenerator(network, origins, destinations, **kwargs)
-    return generator.generate_routes(as_df=as_df, calc_free_flow=calc_free_flow)
+    return generator.generate_routes(as_df=as_df, calc_free_flow=calc_free_flow, max_resample_iterations=max_resample_iterations)
 
 ###########################################################################
 

--- a/janux/visualizers/__init__.py
+++ b/janux/visualizers/__init__.py
@@ -2,3 +2,4 @@ from .animate_edge_attributes import animate_edge_attributes
 from .visualize_edge_attributes import show_edge_attributes
 from .visualize_multi_routes import show_multi_routes
 from .visualize_single_route import show_single_route
+from . import visualization_utils


### PR DESCRIPTION
Make BasicPathGenerator more robust to cases when the number of requested unique paths is lower than requested for some OD pairs (as requested on the last path clustering task meeting).

- Add a max_resample_iterations parameter to generate_routes to avoid potentially infinite sampling loops.
- Allow returning fewer than number_of_paths unique routes when the network does not provide enough distinct paths, with a warning in verbose mode.
- Update docstrings for generate_routes and _pick_routes_from_samples to describe the new behavior.

When enough unique routes exist, the behavior remains the same.