### PR TITLE
Feat/path clustering

### DIFF
--- a/janux/__init__.py
+++ b/janux/__init__.py
@@ -11,6 +11,7 @@ from .path_generators import check_od_integrity
 
 from .path_generators import basic_generator
 from .path_generators import extended_generator
+from .path_generators import clustering_generator
 from .path_generators import heuristic_generator
 
 from . import visualizers

--- a/janux/graph_builders/build_digraph.py
+++ b/janux/graph_builders/build_digraph.py
@@ -15,7 +15,7 @@ from janux.utils import remove_double_quotes
 
 #################################################
 
-def build_digraph(connection_file: str, edge_file: str, route_file: str) -> nx.DiGraph:
+def build_digraph(connection_file: str, edge_file: str, route_file: str, use_clustered_routes : bool = False) -> nx.DiGraph:
     """
     Generates a traffic network graph from XML files.
 
@@ -23,6 +23,7 @@ def build_digraph(connection_file: str, edge_file: str, route_file: str) -> nx.D
         connection_file (str): Path to the connection XML file.
         edge_file (str): Path to the edge XML file.
         route_file (str): Path to the route XML file.
+        use_clustered_routes (bool): Whether to use clustering-routes-compatible version.
 
     Returns:
         nx.DiGraph: A directed graph representing the traffic network.
@@ -33,10 +34,16 @@ def build_digraph(connection_file: str, edge_file: str, route_file: str) -> nx.D
     """
     try:
         # Process connections
-        connections_df = _process_connection_file(connection_file)
+        if use_clustered_routes:
+            connections_df = _process_connection_file_clustering(connection_file)
+        else:
+            connections_df = _process_connection_file(connection_file)
 
         # Process edge attributes
-        edge_attributes_df = _process_edge_file(edge_file)
+        if use_clustered_routes:
+            edge_attributes_df = _process_edge_file_clustering(edge_file)
+        else:
+            edge_attributes_df = _process_edge_file(edge_file)
 
         # Process route attributes
         route_attributes_df = _process_route_file(route_file)
@@ -53,6 +60,38 @@ def build_digraph(connection_file: str, edge_file: str, route_file: str) -> nx.D
             edge_attr='travel_time',
             create_using=nx.DiGraph()
         )
+
+        if use_clustered_routes:
+            def junction_id(node_id: str | None) -> str | None:
+                if node_id is None:
+                    return None
+                node_id = str(node_id)
+                if node_id.startswith(":"):
+                    # internal SUMO node/junction id like ":123_0" -> "123"
+                    return node_id[1:].split("_")[0]            
+                return node_id
+
+            node_attrs = {}
+            for row in edge_attributes_df.itertuples(index=False):
+                if row.edge_id not in traffic_network_graph:
+                    continue
+
+                # There might be multiple connections between nodes. Currently, all are blocked
+                segment_key = (min(row.from_node, row.to_node), max(row.from_node, row.to_node))
+
+                node_attrs[row.edge_id] = {
+                    "from_node": row.from_node,
+                    "to_node": row.to_node,
+                    "segment_key": segment_key,
+                    "undir_key": segment_key,
+                    "junction_from": junction_id(row.from_node),
+                    "junction_to": junction_id(row.to_node),
+                    "is_internal_edge": str(row.edge_id).startswith(":"),
+                    "is_cluster_edge": str(row.edge_id).startswith("cluster"),
+                }
+            
+            nx.set_node_attributes(traffic_network_graph, node_attrs)
+
         return traffic_network_graph
 
     except FileNotFoundError as e:
@@ -72,6 +111,11 @@ def _process_connection_file(connection_file: str) -> pd.DataFrame:
     connections_df = connections_df.rename(columns={'0_x': 'source_edge', '0_y': 'target_edge'})
     return connections_df
 
+def _process_edge_file_clustering(edge_file: str) -> pd.DataFrame:
+    """Parses the edge XML file and returns a DataFrame with edge attributes."""
+    # uses new read xml file function and new column names (instead of 0x and 0y)
+    df = _read_xml_file_clustering(edge_file, 'edge', 'id', 'from', 'to')
+    return df.rename(columns={'id': 'edge_id', 'from': 'from_node', 'to': 'to_node'})
 
 def _process_edge_file(edge_file: str) -> pd.DataFrame:
     """Parses the edge XML file and returns a DataFrame with edge attributes."""
@@ -82,6 +126,10 @@ def _process_edge_file(edge_file: str) -> pd.DataFrame:
     edge_attributes_df['edge_id'] = edge_attributes_df['edge_id'].apply(remove_double_quotes)
     return edge_attributes_df
 
+def _process_connection_file_clustering(connection_file: str) -> pd.DataFrame:
+    """Parses the connection XML file and returns a DataFrame."""
+    df = _read_xml_file_clustering(connection_file, 'connection', 'from', 'to')
+    return df.rename(columns={'from': 'source_edge', 'to': 'target_edge'})
 
 def _process_route_file(route_file: str) -> pd.DataFrame:
     """Parses the route XML file and returns a DataFrame with route attributes."""
@@ -125,3 +173,17 @@ def _read_xml_file(file_path: str, element_name: str, attr1: str, attr2: str) ->
     attr2_values = [el.get(attr2) for el in elements]
 
     return pd.DataFrame(attr1_values), pd.DataFrame(attr2_values)
+
+def _read_xml_file_clustering(file_path: str, element_name: str, *attributes: str) -> pd.DataFrame:
+    """Reads an XML file and extracts specified attributes into a Dataframe"""
+    # 1+ attrs instead of 2, applies remove double quotes, returns 1 df
+    with open(file_path, 'r') as f:
+        data = f.read()
+    parsed_xml = BeautifulSoup(data, "xml")
+    elements = parsed_xml.find_all(element_name)
+
+    data_map = {}
+    for attr in attributes:
+        data_map[attr] = [remove_double_quotes(el.get(attr)) for el in elements]
+
+    return pd.DataFrame(data_map).dropna()

--- a/janux/path_generators/__init__.py
+++ b/janux/path_generators/__init__.py
@@ -5,8 +5,10 @@ from .path_gen_utils import check_od_integrity
 
 from .basic_generator import BasicPathGenerator
 from .extended_generator import ExtendedPathGenerator
+from .clustering_generator import ClusteringPathGenerator
 from .heuristic_based_generator import HeuristicPathGenerator
 
 from .wrapper_functions import basic_generator
 from .wrapper_functions import extended_generator
+from .wrapper_functions import clustering_generator
 from .wrapper_functions import heuristic_generator

--- a/janux/path_generators/clustering_generator.py
+++ b/janux/path_generators/clustering_generator.py
@@ -1,0 +1,402 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.getcwd(), './')))
+
+from typing import List, Union
+
+import networkx as nx
+import pandas as pd
+import numpy as np
+
+from janux.path_generators import calculate_free_flow_time
+from janux.path_generators import iterable_to_string
+from janux.path_generators import paths_to_df
+from janux.path_generators.extended_generator import ExtendedPathGenerator
+
+class ClusteringPathGenerator(ExtendedPathGenerator):
+
+    """
+    Route generator used by the clustering pipeline.
+
+    This class stays separate from `ExtendedPathGenerator` so the classic URB
+    scripts can keep using the original generator behavior while the clustering
+    workflow opts into the fork-derived route-building rules.
+
+    The route-building logic here follows the forked clustered generator behavior:
+
+    - route traversal works on directed edge identifiers
+    - origin/destination collapse is handled through graph node attributes
+    - repeated undirected segments can be blocked
+    - internal junction revisits can be blocked
+
+    The deprecated intermediate generator variants from the fork are not
+    implemented here.
+    """
+
+    def __init__(
+        self,
+        network: nx.DiGraph,
+        origins: list[str],
+        destinations: list[str],
+        **kwargs,
+    ):
+        """
+        Initialize the clustering generator.
+
+        Args:
+            network (nx.DiGraph): Directed traffic graph built from SUMO files.
+            origins (list[str]): Ordered list of origin nodes/edges used as OD inputs.
+            destinations (list[str]): Ordered list of destination nodes/edges used as OD inputs.
+            **kwargs: Optional generator parameters forwarded to the extended base class.
+
+        Notes:
+            The clustering workflow uses a dedicated generator path.
+            Any clustering-specific defaults should be centralized here so the
+            classic generators remain untouched.
+        """
+        kwargs = dict(kwargs)
+
+        # NEW: cluster-only defaults mirror the forked generator behavior while
+        # leaving the classic generators unchanged.
+        kwargs.setdefault("max_resample_iterations", 50)
+        kwargs.setdefault("diverse_selection", False)
+        kwargs.setdefault("keep_generating", False)
+        kwargs.setdefault("min_difference_jaccard", 0.1)
+
+        # NEW: route traversal constraints used by the forked clustered generator.
+        kwargs.setdefault("forbid_abs_reuse", True)
+        kwargs.setdefault("collapse_destination", True)
+        kwargs.setdefault("collapse_origin", True)
+        kwargs.setdefault("forbid_junction_revisit", True)
+        kwargs.setdefault("collapse_internal_junctions", True)
+
+        super().__init__(network, origins, destinations, **kwargs)
+
+        self.max_resample_iterations = kwargs["max_resample_iterations"]
+        self.diverse_selection = kwargs["diverse_selection"]
+        self.keep_generating = kwargs["keep_generating"]
+        self.min_difference_jaccard = kwargs["min_difference_jaccard"]
+        self.forbid_abs_reuse = kwargs["forbid_abs_reuse"]
+        self.collapse_destination = kwargs["collapse_destination"]
+        self.collapse_origin = kwargs["collapse_origin"]
+        self.forbid_junction_revisit = kwargs["forbid_junction_revisit"]
+        self.collapse_internal_junctions = kwargs["collapse_internal_junctions"]
+        self.stats = {"dead_end": 0, "max_length": 0, "no_potential": 0}
+
+        # Keep the clustered generator logging local to this instance.
+        self.logger.propagate = False
+
+    def generate_routes(
+        self,
+        as_df: bool = True,
+        calc_free_flow: bool = False,
+    ) -> Union[pd.DataFrame, dict]:
+        """
+        Generate clustered routes using the forked clustered generator rules.
+
+        Args:
+            as_df (bool): Return a DataFrame when True, otherwise return the raw route dict.
+            calc_free_flow (bool): Include free-flow travel times when True.
+
+        Returns:
+            pd.DataFrame | dict: Generated routes in the same shape as the base generators.
+
+        Notes:
+            The loop mirrors the forked clustered generator behavior and keeps the
+            classic generators unaffected.
+        """
+        assert self.num_samples >= self.number_of_paths, (
+            f"Number of samples ({self.num_samples}) should be "
+            f"at least equal to the number of routes ({self.number_of_paths})"
+        )
+        assert self.max_path_length > 0, f"Maximum path length should be greater than 0"
+        assert self.beta < 0, f"Beta should be less than 0"
+        assert self.shift_parameters_by > 0, f"Shift parameters should be greater than 0"
+        assert self.params_to_shift in ["beta", "max_path_length", "both", "none"], f"Invalid parameter to shift: {self.params_to_shift}. Choose from 'beta', 'max_path_length', 'both', 'none'."
+
+        routes = dict()   # Tuple<od_id, dest_id> : List<routes>
+        for dest_idx, dest_name in self.destinations.items():
+            node_potentials = dict(nx.shortest_path_length(self.network, target=dest_name, weight=self.weight))
+
+            for origin_idx, origin_name in self.origins.items():
+                self.stats = {k: 0 for k in self.stats}
+                sampled_routes = list()
+                iteration_count = 0
+                total_iterations = 0
+                initial_beta, initial_max_path_len = self.beta, self.max_path_length
+
+                while (len(sampled_routes) < self.num_samples) or (len(set(sampled_routes)) < self.number_of_paths):
+
+                    if total_iterations > self.max_resample_iterations + self.num_samples:
+                        self.logger.warning(
+                            f"Hit max iterations for {origin_idx} -> {dest_idx}. Returning {len(set(sampled_routes))} unique paths."
+                        )
+                        break
+
+                    if (self.adaptive) and (iteration_count > self.tolerate_num_iterations):
+                        self.logger.warning(f"Exceeded tolerance for {origin_idx} -> {dest_idx}.")
+                        self.beta, self.max_path_length = self._shift_parameters(self.beta, self.max_path_length)
+                        self.logger.info(f"Beta: {self.beta}, Max Path Length: {self.max_path_length}")
+                        iteration_count = 0
+
+                    path = self._sample_single_route(origin_name, dest_name, node_potentials)
+                    if path is not None:
+                        sampled_routes.append(tuple(path))
+                    iteration_count += 1
+                    total_iterations += 1
+
+                self.beta, self.max_path_length = initial_beta, initial_max_path_len
+                self.logger.info(f"Sampled {len(sampled_routes)} paths for {origin_idx} -> {dest_idx}")
+                routes[(origin_idx, dest_idx)] = self._pick_routes_from_samples(sampled_routes)
+                self.logger.info(f"Selected {len(set(routes[(origin_idx, dest_idx)]))} paths for {origin_idx} -> {dest_idx}")
+
+        if as_df:
+            free_flows = None
+            if calc_free_flow:
+                free_flows = {od: [calculate_free_flow_time(route, self.network) for route in routes[od]] for od in routes}
+            routes_df = paths_to_df(routes, self.origins, self.destinations, free_flows)
+            return routes_df
+        else:
+            return routes
+
+    def _sample_single_route(
+        self,
+        origin: str,
+        destination: str,
+        node_potentials: dict,
+    ) -> Union[List[str], None]:
+        """
+        Sample one route using the forked clustered traversal rules.
+
+        Args:
+            origin (str): Start node/edge for the OD pair.
+            destination (str): Target node/edge for the OD pair.
+            node_potentials (dict): Reverse shortest-path potential map for the target.
+
+        Returns:
+            list[str] | None: A sampled route or `None` when no valid route can be built.
+
+        Notes:
+            This is the clustered route-building logic copied from the forked
+            generator path and kept local to this class.
+        """
+        path = []
+        visited_edges = set()
+        visited_undir = set()
+        visited_junctions = set()
+        current_node = origin
+
+        def junction_id(node_id: str | None) -> str | None:
+            if node_id is None: 
+                return None
+            s = str(node_id)
+            if self.collapse_internal_junctions and s.startswith(":"):
+                return s[1:].split("_")[0]
+            return s
+
+        def get_junc(eid: str, attr: str) -> str | None:
+            # attr is "from_node" or "to_node"
+            val = self.network.nodes.get(eid, {}).get(attr)
+            return junction_id(val)
+
+        def undir_key(eid: str) -> tuple[str, str] | None:
+            d = self.network.nodes.get(eid, {})
+            return d.get("undir_key")
+
+        ######
+        ### STARTING DIRECTION CHOICE:
+        ######
+
+        origin_key = undir_key(origin)
+        start_candidates = [origin]
+        
+        if self.collapse_origin and origin_key:
+            # Find the directed edge going the other way on the same road
+            for node, data in self.network.nodes(data=True):
+                if node == origin: continue
+                if data.get("undir_key") == origin_key:
+                    start_candidates.append(node)
+                    break
+
+        # Choose the optimal starting direction based on the potentials; avoids U-turns
+        current_node = self._logit(start_candidates, node_potentials)
+
+        dest_key = undir_key(destination) if self.collapse_destination else None
+
+        ######
+        ### PATH CREATION:
+        ######
+
+        while True:
+            path.append(current_node)
+            visited_edges.add(current_node)
+
+            # Mark the junction we just arrived at as visited
+            j_arrival = get_junc(current_node, "to_node")
+            if self.forbid_junction_revisit and j_arrival:
+                visited_junctions.add(j_arrival)
+
+            # Mark the undirected (!) edge we just arrived at as visited
+            k = undir_key(current_node)
+            if self.forbid_abs_reuse and k is not None:
+                # Don't "consume" the origin segment immediately so that we can turn around
+                # ~(p && q) <=> ~p || ~q
+                if not (self.collapse_origin and k == origin_key):
+                    visited_undir.add(k)
+
+            # Success - collapsed destination - early exit
+            if self.collapse_destination and dest_key is not None:
+                if k == dest_key:
+                    return path
+
+            ######
+            ### STEP SELECTION:
+            ######
+
+            options = sorted(self.network.neighbors(current_node))
+            
+            # Exact finish
+            # if destination in options:
+            #     dk = undir_key(destination)
+            #     # Allow if not blocking segment OR if it's a tiny 1-edge road we just started on
+            #     if not self.forbid_abs_reuse or (dk not in visited_undir) or (len(path) == 1 and dk == origin_key):
+            #         return path + [destination]
+
+            if destination in options:
+                return path + [destination]
+
+            if len(path) > self.max_path_length:
+                self.stats["max_length"] += 1 # NEW
+                return None
+
+            candidates = []
+
+            for opt in options:
+                if opt in visited_edges:
+                    continue
+
+                p_opt = node_potentials.get(opt, float("inf"))
+                if not np.isfinite(p_opt):
+                    continue
+
+                # Junction-revisit block
+                if self.forbid_junction_revisit:
+                    j_next = get_junc(opt, "to_node")
+                    if j_next and (j_next in visited_junctions):
+                        continue # destination already handled above
+
+                # Undirected segment block
+                if self.forbid_abs_reuse:
+                    ok_key = undir_key(opt)
+                    if ok_key and ok_key in visited_undir:
+                        continue # destination already handled above
+
+                candidates.append(opt)
+
+            # collapsed-destination "hit" via any candidate
+            if self.collapse_destination and dest_key is not None:
+                dest_cands = [c for c in candidates if undir_key(c) == dest_key]
+                if dest_cands:
+                    best = min(dest_cands, key=lambda x: node_potentials.get(x, float("inf")))
+                    return path + [best]
+
+            if not candidates:
+                self.stats["dead_end"] += 1    # NEW
+                # try:
+                #     fallback = nx.shortest_path(self.network, origin, destination)
+                #     # print(fallback)
+                #     return fallback
+                # except nx.NetworkXNoPath:
+                #     pass
+                return None  # truly unreachable
+
+            cur_p = node_potentials.get(current_node, float("inf"))
+            if not np.isfinite(cur_p):
+                self.stats["no_potential"] += 1 # NEW
+                return None
+
+            current_node = self._logit(candidates, node_potentials)
+
+    def _pick_routes_from_samples(self, sampled_routes: list[tuple]) -> list[tuple]:
+        """
+        Select the final route set for an OD pair.
+
+        Args:
+            sampled_routes (list[tuple]): Sampled candidate routes for one OD pair.
+
+        Returns:
+            list[tuple]: The selected route set.
+
+        Notes:
+            This uses the forked selection rules so the generator can either keep
+            the classic unique-route behavior or opt into the diversity-based path.
+        """
+        assert self.number_of_paths > 0, f"Number of paths should be greater than 0"
+
+        if not sampled_routes:
+            return []
+
+        if self.diverse_selection:
+            route_counts = pd.Series(sampled_routes).value_counts()
+            unique_routes = route_counts.index.tolist()
+
+            shortest_route_len = min(len(r) for r in unique_routes)
+            max_allowed_len = 10 * shortest_route_len
+            candidates = [r for r in unique_routes if len(r) <= max_allowed_len]
+
+            num_too_long = len(unique_routes) - len(candidates)
+            if not candidates:
+                return []
+
+            picked_routes = [candidates.pop(0)]
+            min_dists_to_set = [self._jaccard_distance(c, picked_routes[0]) for c in candidates]
+            rejected_jaccard = 0
+
+            while candidates:
+                if not self.keep_generating and len(picked_routes) >= self.number_of_paths:
+                    break
+
+                max_d = max(min_dists_to_set)
+                best_idx = min_dists_to_set.index(max_d)
+
+                if max_d < self.min_difference_jaccard:
+                    rejected_jaccard = len(candidates)
+                    break
+
+                best_cand = candidates.pop(best_idx)
+                min_dists_to_set.pop(best_idx)
+                picked_routes.append(best_cand)
+
+                for i in range(len(candidates)):
+                    new_dist = self._jaccard_distance(candidates[i], best_cand)
+                    if new_dist < min_dists_to_set[i]:
+                        min_dists_to_set[i] = new_dist
+
+            surplus = len(candidates) if rejected_jaccard == 0 else 0
+            self.logger.info(
+                f"Selection: {len(picked_routes)} kept, {num_too_long} too long, "
+                f"{rejected_jaccard} too similar, {surplus} surplus unique paths."
+            )
+            return picked_routes
+
+        sampled_routes_by_str = np.array([iterable_to_string(route, ",") for route in sampled_routes])
+        unique_routes, route_counts = np.unique(sampled_routes_by_str, return_counts=True)
+        sampling_probabilities = route_counts / route_counts.sum()
+
+        n_to_pick = min(self.number_of_paths, len(unique_routes))
+        if n_to_pick == 0:
+            return []
+
+        if n_to_pick < self.number_of_paths and self.verbose:
+            self.logger.warning(
+                f"Requested {self.number_of_paths} unique paths but only {len(unique_routes)} found; returning {n_to_pick}."
+            )
+
+        picked_routes = self.rng.choice(unique_routes, size=n_to_pick, p=sampling_probabilities, replace=False)
+        return [tuple(route.split(",")) for route in picked_routes]
+
+    def _jaccard_distance(self, route_A: tuple[str], route_B: tuple[str]) -> float:
+        route_A_edges = set(route_A)
+        route_B_edges = set(route_B)
+        return 1 - len(route_A_edges & route_B_edges) / len(route_A_edges | route_B_edges)

--- a/janux/path_generators/clustering_generator.py
+++ b/janux/path_generators/clustering_generator.py
@@ -17,21 +17,12 @@ from janux.path_generators.extended_generator import ExtendedPathGenerator
 class ClusteringPathGenerator(ExtendedPathGenerator):
 
     """
-    Route generator used by the clustering pipeline.
-
-    This class stays separate from `ExtendedPathGenerator` so the classic URB
-    scripts can keep using the original generator behavior while the clustering
-    workflow opts into the fork-derived route-building rules.
-
-    The route-building logic here follows the forked clustered generator behavior:
+    Route generator used by the clustering pipeline with :
 
     - route traversal works on directed edge identifiers
     - origin/destination collapse is handled through graph node attributes
     - repeated undirected segments can be blocked
     - internal junction revisits can be blocked
-
-    The deprecated intermediate generator variants from the fork are not
-    implemented here.
     """
 
     def __init__(
@@ -93,18 +84,12 @@ class ClusteringPathGenerator(ExtendedPathGenerator):
         calc_free_flow: bool = False,
     ) -> Union[pd.DataFrame, dict]:
         """
-        Generate clustered routes using the forked clustered generator rules.
-
         Args:
             as_df (bool): Return a DataFrame when True, otherwise return the raw route dict.
             calc_free_flow (bool): Include free-flow travel times when True.
 
         Returns:
             pd.DataFrame | dict: Generated routes in the same shape as the base generators.
-
-        Notes:
-            The loop mirrors the forked clustered generator behavior and keeps the
-            classic generators unaffected.
         """
         assert self.num_samples >= self.number_of_paths, (
             f"Number of samples ({self.num_samples}) should be "
@@ -167,8 +152,6 @@ class ClusteringPathGenerator(ExtendedPathGenerator):
         node_potentials: dict,
     ) -> Union[List[str], None]:
         """
-        Sample one route using the forked clustered traversal rules.
-
         Args:
             origin (str): Start node/edge for the OD pair.
             destination (str): Target node/edge for the OD pair.
@@ -176,10 +159,6 @@ class ClusteringPathGenerator(ExtendedPathGenerator):
 
         Returns:
             list[str] | None: A sampled route or `None` when no valid route can be built.
-
-        Notes:
-            This is the clustered route-building logic copied from the forked
-            generator path and kept local to this class.
         """
         path = []
         visited_edges = set()
@@ -327,10 +306,6 @@ class ClusteringPathGenerator(ExtendedPathGenerator):
 
         Returns:
             list[tuple]: The selected route set.
-
-        Notes:
-            This uses the forked selection rules so the generator can either keep
-            the classic unique-route behavior or opt into the diversity-based path.
         """
         assert self.number_of_paths > 0, f"Number of paths should be greater than 0"
 

--- a/janux/path_generators/clustering_generator.py
+++ b/janux/path_generators/clustering_generator.py
@@ -17,12 +17,14 @@ from janux.path_generators.extended_generator import ExtendedPathGenerator
 class ClusteringPathGenerator(ExtendedPathGenerator):
 
     """
-    Route generator used by the clustering pipeline with :
-
-    - route traversal works on directed edge identifiers
-    - origin/destination collapse is handled through graph node attributes
-    - repeated undirected segments can be blocked
-    - internal junction revisits can be blocked
+    Route generator used by the clustering pipeline with extra functionalities:
+    - block repeated undirected segments revisits
+    - block junction revisits
+    - origin/destination collapse
+    - diverse selection mode (choosing subsequent paths not based on their sample counts but on their similarity to previously chosen ones - least similar are prioritized)
+    - max_resample_iterations eliminates route generation stalling by allowing to terminate early and return less paths than requested
+    
+    Mainly meant to be used with the path clustering pipeline.
     """
 
     def __init__(
@@ -84,6 +86,8 @@ class ClusteringPathGenerator(ExtendedPathGenerator):
         calc_free_flow: bool = False,
     ) -> Union[pd.DataFrame, dict]:
         """
+        Generates routes between origin-destination pairs in the network.
+
         Args:
             as_df (bool): Return a DataFrame when True, otherwise return the raw route dict.
             calc_free_flow (bool): Include free-flow travel times when True.
@@ -152,6 +156,8 @@ class ClusteringPathGenerator(ExtendedPathGenerator):
         node_potentials: dict,
     ) -> Union[List[str], None]:
         """
+        Samples a single route between an origin and a destination in the network.
+                
         Args:
             origin (str): Start node/edge for the OD pair.
             destination (str): Target node/edge for the OD pair.

--- a/janux/path_generators/wrapper_functions.py
+++ b/janux/path_generators/wrapper_functions.py
@@ -33,6 +33,20 @@ def extended_generator(network: nx.DiGraph,
 
 ###########################################################################
 
+######################### Clustering Path Generator #########################
+
+from .clustering_generator import ClusteringPathGenerator
+
+def clustering_generator(network: nx.DiGraph,
+                         origins: list[str],
+                         destinations: list[str],
+                         as_df: bool = False,
+                         calc_free_flow: bool = False,
+                         **kwargs) -> pd.DataFrame:
+    generator = ClusteringPathGenerator(network, origins, destinations, **kwargs)
+    return generator.generate_routes(as_df=as_df, calc_free_flow=calc_free_flow)
+###########################################################################
+
 ######################### Heuristic Path Generator ########################
 
 from .heuristic_based_generator import HeuristicPathGenerator


### PR DESCRIPTION
Add ClusteringPathGenerator - an upgraded version of the ExtendedPathGenerator. Mainly meant to be used with the path clustering pipeline (https://github.com/Blato122/path-clustering). It offers a couple of extra functionalities such as: 
- block repeated undirected segments revisits
- block junction revisits
- origin/destination collapse
- diverse selection mode (choosing subsequent paths not based on their sample counts but on their similarity to previously chosen ones - least similar are prioritized)
- max_resample_iterations eliminates route generation stalling by allowing to terminate early and return less paths than requested